### PR TITLE
Changes to README.md file to clarify that this public repo is for training purposes only - Issue#1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Status](https://travis-ci.org/ministryofjustice/c100-application.svg?branch=mast
 
 Work in progress: This is a Rails application to enable citizens
 to complete the C100 form. It is based on software patterns developed for the
-[Appeal to the Tax Tribunal][taxtribs] application. This iteration of the app has been created as a learning project.
+[Appeal to the Tax Tribunal][taxtribs] application. This iteration of the app has been created as a learning project to be considered independently of the original app.
 
 ## Heroku demo.
 


### PR DESCRIPTION
Made changes to the README.md to clarify that this public repo is for training purposes only - issue #1:
- change title to Family Justice C100 Service - Copy for training purposes
- add as preliminary paragraph: This is a fork of the live project, used to demonstrate and refine collaboration within the development team. All informational content should be considered fake.
  